### PR TITLE
Added role check to moderation_action admin endpoint

### DIFF
--- a/admin/routes.py
+++ b/admin/routes.py
@@ -92,6 +92,7 @@ def sources():
 
 @admin.route('/moderation/<checksum>/<action>')
 @login_required
+@role_required('Moderator')
 def moderation_action(checksum, action):
     checksum = secure_filename(checksum)
     moderation_entry = db.session.query(ModeratedBinariesModel).filter_by(checksum=checksum).first()


### PR DESCRIPTION
Corrected a small oversight I happened to notice while looking at the code, where the endpoint for performing moderation actions was accessible to all logged in users regardless of role, as it lacked the role_required decorator.

Not a significant issue, as there shouldn't be any untrusted "guest" users anyways, and moderator is the next lowest privileged role.