### PR TITLE
Enable pulling releases from Forgejo-based services

### DIFF
--- a/src/main/java/org/oscwii/repositorymanager/model/app/OSCMeta.java
+++ b/src/main/java/org/oscwii/repositorymanager/model/app/OSCMeta.java
@@ -28,7 +28,7 @@ public record OSCMeta(String name, String author, String[] authors, String categ
                       List<String> peripherals, String version, EnumSet<Flag> flags,
                       Source source, List<Treatment> treatments)
 {
-    public record Source(String type, Format format, String url, String file,
+    public record Source(String type, String host, Format format, String url, String file,
                          String userAgent, Set<String> additionalFiles)
     {
         public enum Format

--- a/src/main/java/org/oscwii/repositorymanager/sources/impl/GitHubSourceDownloader.java
+++ b/src/main/java/org/oscwii/repositorymanager/sources/impl/GitHubSourceDownloader.java
@@ -50,15 +50,20 @@ public class GitHubSourceDownloader extends BaseSourceDownloader
         OSCMeta.Source source = app.getMeta().source();
         Request.Builder request = new Request.Builder();
 
-        if(!config.getGithubToken().isEmpty())
-        {
-            logger.info("  - Authenticating with GitHub");
-            request.addHeader("Authorization", "token " + config.getGithubToken());
-        }
-        else
-            logger.info("  - No valid GitHub token found, using unauthenticated requests.");
+        String apiHost = source.host() + "/api/v1";
+        if (source.host() == null) {
+            apiHost = "https://api.github.com";
 
-        return request.url(LATEST_RELEASE.formatted(source.url()))
+            if(!config.getGithubToken().isEmpty())
+            {
+                logger.info("  - Authenticating with GitHub");
+                request.addHeader("Authorization", "token " + config.getGithubToken());
+            }
+            else
+                logger.info("  - No valid GitHub token found, using unauthenticated requests.");
+        }
+
+        return request.url(LATEST_RELEASE.formatted(apiHost, source.url()))
                 .addHeader("User-Agent", config.getUserAgent())
                 .build();
     }
@@ -106,5 +111,5 @@ public class GitHubSourceDownloader extends BaseSourceDownloader
         }
     }
 
-    private static final String LATEST_RELEASE = "https://api.github.com/repos/%s/releases/latest";
+    private static final String LATEST_RELEASE = "%s/repos/%s/releases/latest";
 }

--- a/src/main/java/org/oscwii/repositorymanager/utils/serializers/SourceTypeAdapter.java
+++ b/src/main/java/org/oscwii/repositorymanager/utils/serializers/SourceTypeAdapter.java
@@ -61,6 +61,7 @@ public class SourceTypeAdapter implements JsonDeserializer<OSCMeta.Source>
                 context.deserialize(additionalFilesArr, new TypeToken<>(){}.getType());
 
         return new OSCMeta.Source(type,
+                obj.has("host") ? obj.get("host").getAsString() : null,
                 context.deserialize(obj.get("format"), OSCMeta.Source.Format.class),
                 url,
                 file,


### PR DESCRIPTION
This PR adds a host setting for the GitHub source, so services like [Codeberg](https://codeberg.org) are supported as they have an API that's compatible w/ GitHub.
```
    "source": {
        "type": "github_release",
        "host": "https://codeberg.org",
        "format": "zip",
        "repository": "boreal/GRRLIB-Examples-Collection",
        "file": "release.zip"
    }
```